### PR TITLE
Use better embedded JS delimiter

### DIFF
--- a/Contents/Resources/SyntaxDefinition.xml
+++ b/Contents/Resources/SyntaxDefinition.xml
@@ -65,7 +65,7 @@
                 </begin>
                 
                 <end>
-                    <regex>\n\s*\n</regex>
+                    <regex>\n\s*\n\s*[-=%\.#:]</regex>
                 </end>
                 
                 <import mode="JavaScript"/>


### PR DESCRIPTION
This allows embedded JS to have empty lines in the code. This solution is not perfect either but covers more cases than the original solution (which ends the JS highlighting after any blank line).

The perfect solution would be based on the indentation. However, as far as I know this is not possible with the Coda/SubEthaEdit syntax engine.
