### PR TITLE
Fix double line insertion

### DIFF
--- a/Contents/Resources/ModeSettings.xml
+++ b/Contents/Resources/ModeSettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-  <recognition>
-    <extension>haml</extension>
-    <extension>html.haml</extension>
-  </recognition>
+	<recognition>
+		<extension>haml</extension>
+		<extension>html.haml</extension>
+	</recognition>
 </settings>

--- a/Contents/Resources/RegexSymbols.xml
+++ b/Contents/Resources/RegexSymbols.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <symbols>
-
-    <!-- 
+	<!-- 
     The <symbol> tag specifies what is being shown in the fuction popup.
     It features the following attributes, all optional if not noted otherwise:
         id
@@ -23,10 +22,9 @@
             
         The example shows an symbol name "First example" with the image SymbolM
         and an indentation of 1.
-    -->    
-    <symbol id="First Example" image="SymbolM" indentation="1">
-        
-        <!-- 
+    -->
+	<symbol id="First Example" image="SymbolM" indentation="1">
+		<!-- 
             The regex tag specifies the regular expression that is search for this
             symbol. It contains a Ruby-flavored regular expression. If groups is
             specified in the regular expression the first group is used for the
@@ -36,10 +34,8 @@
             Tip: Case sensitivity can be set to ignore by including (?i) in your
                  expression.
         -->
-        
-        <regex>(function[^\n\r]*)</regex>
-
-        <!-- 
+		<regex>(function[^\n\r]*)</regex>
+		<!-- 
             The postprocess tag specifies the find and replaces that should
             be executed on the found string. You can use groups like \1 and the
             like. It contains a Ruby-flavored regular expression. 
@@ -49,17 +45,14 @@
             with a empty string. Then it searches all occurances of "foo" and
             replaces them with "bar".
         -->
-                
-        <postprocess>
-            <find>\([^\)]*\)</find>
-            <replace></replace>
-            <find>foo</find>
-            <replace>bar</replace>
-        </postprocess>
-    </symbol>
-
-    <symbol id="Second Example" font-weight="bold" image="SymbolF" indentation="0">
-        <regex>foobar</regex>
-    </symbol>
-    
+		<postprocess>
+			<find>\([^\)]*\)</find>
+			<replace/>
+			<find>foo</find>
+			<replace>bar</replace>
+		</postprocess>
+	</symbol>
+	<symbol id="Second Example" font-weight="bold" image="SymbolF" indentation="0">
+		<regex>foobar</regex>
+	</symbol>
 </symbols>

--- a/Contents/Resources/SyntaxDefinition.xml
+++ b/Contents/Resources/SyntaxDefinition.xml
@@ -59,7 +59,7 @@
 				</end>
 				<import mode="JavaScript"/>
 			</state>
-			<state id="Ruby" usesymbolsfrommode="Ruby" useautocompletefrommode="Ruby" foldable="yes" scope="meta.default">
+			<state id="Ruby" usesymbolsfrommode="Ruby" useautocompletefrommode="Ruby" foldable="no" scope="meta.default">
 				<begin>
 					<regex>[-=]</regex>
 				</begin>

--- a/Contents/Resources/SyntaxDefinition.xml
+++ b/Contents/Resources/SyntaxDefinition.xml
@@ -65,7 +65,7 @@
                 </begin>
                 
                 <end>
-                    <regex>\n\s*\n</regex>
+                    <regex>\n\s*\n\s*[-=%\.#:]</regex>
                 </end>
                 
                 <import mode="JavaScript"/>

--- a/Contents/Resources/SyntaxDefinition.xml
+++ b/Contents/Resources/SyntaxDefinition.xml
@@ -73,7 +73,7 @@
 
       			<state id="Ruby" usesymbolsfrommode="Ruby" useautocompletefrommode="Ruby" foldable="yes" scope="meta.default">
   			<begin><regex>[-=]</regex></begin>
-  				<end><regex>\n</regex></end>
+  				<end><regex>(?&lt;!,)\n</regex></end>
   
   				<keywords id="ERB Delimiter" useforautocomplete="no" scope="markup.processing.languageswitch">				
             <regex>\n</regex>

--- a/Contents/Resources/SyntaxDefinition.xml
+++ b/Contents/Resources/SyntaxDefinition.xml
@@ -1,136 +1,136 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE syntax SYSTEM "syntax.dtd">
-
 <syntax>
-    <head>
-        <name>HAML Syntax</name>
-
-        <autocompleteoptions use-spelling-dictionary="no" />
-
-        <charsintokens>
-            <![CDATA[_0987654321abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@#%.{}]]>
-        </charsintokens>
-    </head>
-
-    <states>
-        <default id="Base" scope="meta.default">
-      			<state id="Single Tag" foldable="no" scope="markup.tag">
-        				<begin>
-          					<regex>\s*%</regex>
-        				</begin>
-        				
-        				<end>
-                    <regex>\w+</regex>
-        				</end>
-        				
-        				<import/>
-      			</state>
-
-      			<state id="Tag Attributes" foldable="no" scope="markup.tag.attribute.name">
-      			   <begin>
-      			       <regex>{</regex>
-      			   </begin>
-      			   
-      			   <end>
-      			       <regex>}</regex>
-      			   </end>
-      			   
-               <state id="String" type="string" scope="markup.tag.attribute.value.string">
-                   <begin><regex>"</regex></begin>
-                   <end><regex>"</regex></end>
-               </state>
-
-               <state id="SingleString" type="string" scope="markup.tag.attribute.value.string">
-                   <begin><regex>'</regex></begin>
-                   <end><regex>'</regex></end>
-               </state>
-      			</state>
-
-      			<state id="Tag Class or ID" foldable="no" scope="markup.tag.attribute.name">
-        				<begin>
-          					<regex>[#\.]</regex>
-        				</begin>
-        				
-        				<end>
-                    <regex>[-_\d\w]+</regex>
-        				</end>
-        				
-        				<import/>
-      			</state>
-      			
-            <state id="Inline JavaScript" usesymbolsfrommode="JavaScript" useautocompletefrommode="JavaScript" foldable="yes" indent="yes" scope="meta.block.js">
-            
-                <begin>
-                    <regex>^\s+:javascript</regex>
-                </begin>
-                
-                <end>
-                    <regex>\n\s*\n\s*[-=%\.#:]</regex>
-                </end>
-                
-                <import mode="JavaScript"/>
-            </state>
-
-      			<state id="Ruby" usesymbolsfrommode="Ruby" useautocompletefrommode="Ruby" foldable="yes" scope="meta.default">
-  			<begin><regex>[-=]</regex></begin>
-  				<end><regex>(?&lt;!,)\n</regex></end>
-  
-  				<keywords id="ERB Delimiter" useforautocomplete="no" scope="markup.processing.languageswitch">				
-            <regex>\n</regex>
-  				</keywords>
-  
-  				<import mode="Ruby" keywords-only="yes" />
-  
-  				<state-link mode="Ruby" state="String with double quotes" />
-  				<state-link mode="Ruby" state="String with single quotes" />
-  				<state-link mode="Ruby" state="Heredoc" />
-  				<state-link mode="Ruby" state="Heredoc Indented End" />
-                  <state id="ERB Percent Strings with Interpolation" type="string" foldable="yes" scope="string.percentage">
-                  <begin><regex>%Q?(?'erbpercentstringchar'[^\s{\[\(&lt;A-Za-z0-9>])</regex></begin>
-                  <end><regex>(?#see-insert-start-group:erbpercentstringchar)</regex></end>
-                      <state-link mode="Ruby" state="Interpolation"/>
-                  </state>
-                  <state id="ERB Percent Strings without Interpolation" type="string" foldable="yes" scope="string.percentage">
-                  <begin><regex>%q(?'erbpercentstringcharnointer'[^\s{\[\(&lt;A-Za-z0-9>])</regex></begin>
-                  <end><regex>(?#see-insert-start-group:erbpercentstringcharnointer)</regex></end>
-                  </state>
-  				<state-link mode="Ruby" state="Percent Strings {" />
-  				<state-link mode="Ruby" state="Percent Strings (" />
-  				<state-link mode="Ruby" state="Percent Strings &lt;" />
-  				<state-link mode="Ruby" state="Percent Strings [" />
-  				<state-link mode="Ruby" state="Percent Strings Q {" />
-  				<state-link mode="Ruby" state="Percent Strings Q (" />
-  				<state-link mode="Ruby" state="Percent Strings Q &lt;" />
-  				<state-link mode="Ruby" state="Percent Strings Q [" />
-  				<state-link mode="Ruby" state="Backticks" />
-  				<state-link mode="Ruby" state="Percent Execution" />
-  				<state-link mode="Ruby" state="Percent Execution {" />
-  				<state-link mode="Ruby" state="Percent Execution (" />
-  				<state-link mode="Ruby" state="Percent Execution &lt;" />
-  				<state-link mode="Ruby" state="Percent Execution [" />
-  				<state-link mode="Ruby" state="Regexp" />
-  				<state-link mode="Ruby" state="Percent Regex" />
-  				<state-link mode="Ruby" state="Percent Regex {" />
-  				<state-link mode="Ruby" state="Percent Regex (" />
-  				<state-link mode="Ruby" state="Percent Regex &lt;" />
-  				<state-link mode="Ruby" state="Percent Regex [" />
-  				<state-link mode="Ruby" state="Percent Symbol" />
-  				<state-link mode="Ruby" state="Percent Symbol {" />
-  				<state-link mode="Ruby" state="Percent Symbol (" />
-  				<state-link mode="Ruby" state="Percent Symbol &lt;" />
-  				<state-link mode="Ruby" state="Percent Symbol [" />
-  				<state-link mode="Ruby" state="Percent Array" />
-  				<state-link mode="Ruby" state="Percent Array {" />
-  				<state-link mode="Ruby" state="Percent Array (" />
-  				<state-link mode="Ruby" state="Percent Array &lt;" />
-  				<state-link mode="Ruby" state="Percent Array [" />
-  				
-  				<state id="Singleline Comment" type="comment" scope="comment.line.double-slash">
-  					<begin><regex>#</regex></begin>
-  					<end><regex>(?:.(?=[\n\r]))|(?:.(?=%>|-%>))</regex></end>
-  					<import mode="Base" state="EmailAndURLContainerState" keywords-only="yes"/>
-  				</state>
-  			</state>
-        </default>
-    </states>
+	<head>
+		<name>HAML Syntax</name>
+		<autocompleteoptions use-spelling-dictionary="no"/>
+		<charsintokens><![CDATA[_0987654321abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@#%.{}]]></charsintokens>
+	</head>
+	<states>
+		<default id="Base" scope="meta.default">
+			<state id="Single Tag" foldable="no" scope="markup.tag">
+				<begin>
+					<regex>\s*%</regex>
+				</begin>
+				<end>
+					<regex>\w+</regex>
+				</end>
+				<import/>
+			</state>
+			<state id="Tag Attributes" foldable="no" scope="markup.tag.attribute.name">
+				<begin>
+					<regex>{</regex>
+				</begin>
+				<end>
+					<regex>}</regex>
+				</end>
+				<state id="String" type="string" scope="markup.tag.attribute.value.string">
+					<begin>
+						<regex>"</regex>
+					</begin>
+					<end>
+						<regex>"</regex>
+					</end>
+				</state>
+				<state id="SingleString" type="string" scope="markup.tag.attribute.value.string">
+					<begin>
+						<regex>'</regex>
+					</begin>
+					<end>
+						<regex>'</regex>
+					</end>
+				</state>
+			</state>
+			<state id="Tag Class or ID" foldable="no" scope="markup.tag.attribute.name">
+				<begin>
+					<regex>[#\.]</regex>
+				</begin>
+				<end>
+					<regex>[-_\d\w]+</regex>
+				</end>
+				<import/>
+			</state>
+			<state id="Inline JavaScript" usesymbolsfrommode="JavaScript" useautocompletefrommode="JavaScript" foldable="yes" indent="yes" scope="meta.block.js">
+				<begin>
+					<regex>^\s+:javascript</regex>
+				</begin>
+				<end>
+					<regex>\n\s*\n\s*[-=%\.#:]</regex>
+				</end>
+				<import mode="JavaScript"/>
+			</state>
+			<state id="Ruby" usesymbolsfrommode="Ruby" useautocompletefrommode="Ruby" foldable="yes" scope="meta.default">
+				<begin>
+					<regex>[-=]</regex>
+				</begin>
+				<end>
+					<regex>(?&lt;!,)\n</regex>
+				</end>
+				<keywords id="ERB Delimiter" useforautocomplete="no" scope="markup.processing.languageswitch">
+					<regex>\n</regex>
+				</keywords>
+				<import mode="Ruby" keywords-only="yes"/>
+				<state-link mode="Ruby" state="String with double quotes"/>
+				<state-link mode="Ruby" state="String with single quotes"/>
+				<state-link mode="Ruby" state="Heredoc"/>
+				<state-link mode="Ruby" state="Heredoc Indented End"/>
+				<state id="ERB Percent Strings with Interpolation" type="string" foldable="yes" scope="string.percentage">
+					<begin>
+						<regex>%Q?(?'erbpercentstringchar'[^\s{\[\(&lt;A-Za-z0-9&gt;])</regex>
+					</begin>
+					<end>
+						<regex>(?#see-insert-start-group:erbpercentstringchar)</regex>
+					</end>
+					<state-link mode="Ruby" state="Interpolation"/>
+				</state>
+				<state id="ERB Percent Strings without Interpolation" type="string" foldable="yes" scope="string.percentage">
+					<begin>
+						<regex>%q(?'erbpercentstringcharnointer'[^\s{\[\(&lt;A-Za-z0-9&gt;])</regex>
+					</begin>
+					<end>
+						<regex>(?#see-insert-start-group:erbpercentstringcharnointer)</regex>
+					</end>
+				</state>
+				<state-link mode="Ruby" state="Percent Strings {"/>
+				<state-link mode="Ruby" state="Percent Strings ("/>
+				<state-link mode="Ruby" state="Percent Strings &lt;"/>
+				<state-link mode="Ruby" state="Percent Strings ["/>
+				<state-link mode="Ruby" state="Percent Strings Q {"/>
+				<state-link mode="Ruby" state="Percent Strings Q ("/>
+				<state-link mode="Ruby" state="Percent Strings Q &lt;"/>
+				<state-link mode="Ruby" state="Percent Strings Q ["/>
+				<state-link mode="Ruby" state="Backticks"/>
+				<state-link mode="Ruby" state="Percent Execution"/>
+				<state-link mode="Ruby" state="Percent Execution {"/>
+				<state-link mode="Ruby" state="Percent Execution ("/>
+				<state-link mode="Ruby" state="Percent Execution &lt;"/>
+				<state-link mode="Ruby" state="Percent Execution ["/>
+				<state-link mode="Ruby" state="Regexp"/>
+				<state-link mode="Ruby" state="Percent Regex"/>
+				<state-link mode="Ruby" state="Percent Regex {"/>
+				<state-link mode="Ruby" state="Percent Regex ("/>
+				<state-link mode="Ruby" state="Percent Regex &lt;"/>
+				<state-link mode="Ruby" state="Percent Regex ["/>
+				<state-link mode="Ruby" state="Percent Symbol"/>
+				<state-link mode="Ruby" state="Percent Symbol {"/>
+				<state-link mode="Ruby" state="Percent Symbol ("/>
+				<state-link mode="Ruby" state="Percent Symbol &lt;"/>
+				<state-link mode="Ruby" state="Percent Symbol ["/>
+				<state-link mode="Ruby" state="Percent Array"/>
+				<state-link mode="Ruby" state="Percent Array {"/>
+				<state-link mode="Ruby" state="Percent Array ("/>
+				<state-link mode="Ruby" state="Percent Array &lt;"/>
+				<state-link mode="Ruby" state="Percent Array ["/>
+				<state id="Singleline Comment" type="comment" scope="comment.line.double-slash">
+					<begin>
+						<regex>#</regex>
+					</begin>
+					<end>
+						<regex>(?:.(?=[\n\r]))|(?:.(?=%&gt;|-%&gt;))</regex>
+					</end>
+					<import mode="Base" state="EmailAndURLContainerState" keywords-only="yes"/>
+				</state>
+			</state>
+		</default>
+	</states>
 </syntax>


### PR DESCRIPTION
Fixes #2. The double line insertion happens when pressing Enter on a ERB line. Making ERB lines not foldable (which doesn't make much sense anyways), resolves this bug.
